### PR TITLE
Fixed a typo in init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,7 +72,7 @@ class letsencrypt (
     $hook_content = undef,
     $letsencrypt_host = undef,
     $letsencrypt_ca = 'https://acme-v01.api.letsencrypt.org/directory',
-    $lentsencrypt_contact_email = undef,
+    $letsencrypt_contact_email = undef,
     $letsencrypt_proxy = undef,
     $dh_param_size = 2048,
 ){

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -97,7 +97,7 @@ class letsencrypt (
                 letsencrypt_ca             => $letsencrypt_ca,
                 hook_source                => $hook_source,
                 hook_content               => $hook_content,
-                lentsencrypt_contact_email => $lentsencrypt_contact_email,
+                letsencrypt_contact_email  => $letsencrypt_contact_email,
                 letsencrypt_proxy          => $letsencrypt_proxy,
             }
         }

--- a/manifests/request/handler.pp
+++ b/manifests/request/handler.pp
@@ -35,7 +35,7 @@ class letsencrypt::request::handler(
     $letsencrypt_ca,
     $hook_source,
     $hook_content,
-    $lentsencrypt_contact_email,
+    $letsencrypt_contact_email,
     $letsencrypt_proxy,
 ){
 

--- a/templates/letsencrypt.conf.erb
+++ b/templates/letsencrypt.conf.erb
@@ -59,7 +59,7 @@ PRIVATE_KEY_JSON="<%= @handler_base_dir -%>/<%= @private_key_name -%>.json"
 
 # E-mail to use during the registration (default: <unset>)
 <% if @lentsencrypt_contact_email -%>
-CONTACT_EMAIL=<%= @lentsencrypt_contact_email %>
+CONTACT_EMAIL=<%= @letsencrypt_contact_email %>
 <%- else -%>
 #CONTACT_EMAIL=
 <%- end %>
@@ -74,4 +74,3 @@ https_proxy="<%= @letsencrypt_proxy -%>"
 export http_proxy
 export https_proxy
 <%- end %>
-

--- a/templates/letsencrypt.conf.erb
+++ b/templates/letsencrypt.conf.erb
@@ -58,7 +58,7 @@ PRIVATE_KEY_JSON="<%= @handler_base_dir -%>/<%= @private_key_name -%>.json"
 #KEY_ALGO=rsa
 
 # E-mail to use during the registration (default: <unset>)
-<% if @lentsencrypt_contact_email -%>
+<% if @letsencrypt_contact_email -%>
 CONTACT_EMAIL=<%= @letsencrypt_contact_email %>
 <%- else -%>
 #CONTACT_EMAIL=


### PR DESCRIPTION
Fixed a typo in `init.pp` for the `letsencrypt_contact_email` parameter.
