### PR TITLE
add cwd to create le command

### DIFF
--- a/manifests/request.pp
+++ b/manifests/request.pp
@@ -86,6 +86,7 @@ define letsencrypt::request (
 
     exec { "create-certificate-${domain}" :
         user    => 'letsencrypt',
+        cwd     => $letsencrypt_sh_dir,
         group   => 'letsencrypt',
         unless  => $le_check_command,
         command => $le_command,


### PR DESCRIPTION
some hooks may require additional files to find, so its usefull to cwd to the $letsencrypt_sh_dir before execution
