### PR TITLE
Add cwd to create-certificate

### DIFF
--- a/manifests/request.pp
+++ b/manifests/request.pp
@@ -86,6 +86,7 @@ define letsencrypt::request (
 
     exec { "create-certificate-${domain}" :
         user    => 'letsencrypt',
+        cwd     => $letsencrypt_sh_dir,
         group   => 'letsencrypt',
         unless  => $le_check_command,
         command => $le_command,


### PR DESCRIPTION
Add cwd to create-certificate-${domain} since the ovh-python-hook needs to create a .id_temp file
