### PR TITLE
Change init params to inherited, fixes #23

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,30 +69,22 @@
 #
 class letsencrypt (
     $domains = [],
-    $letsencrypt_sh_git_url = 'https://github.com/lukas2511/dehydrated.git',
+    $letsencrypt_sh_git_url = $::letsencrypt::params::letsencrypt_sh_git_url,
     $dehydrated_git_url = $letsencrypt_sh_git_url,
-    $challengetype = 'dns-01',
+    $challengetype = $::letsencrypt::params::challengetype,
     $hook_source = undef,
     $hook_content = undef,
-    $letsencrypt_host = undef,
-    $letsencrypt_ca = 'https://acme-v01.api.letsencrypt.org/directory',
+    $letsencrypt_host = $::letsencrypt::params::letsencrypt_host,
+    $letsencrypt_ca = $::letsencrypt::params::letsencrypt_ca,
     $letsencrypt_contact_email = undef,
     $letsencrypt_proxy = undef,
-    $dh_param_size = 2048,
-    $manage_packages = true,
-){
+    $dh_param_size = $::letsencrypt::params::dh_param_size,
+    $manage_packages = $::letsencrypt::params::manage_packages,
+) inherits ::letsencrypt::params {
 
-    require ::letsencrypt::params
     require ::letsencrypt::setup
 
-
-    $letsencrypt_real_host = pick(
-        $letsencrypt_host,
-        $::servername,
-        $::puppetmaster
-    )
-
-    if ($::fqdn == $letsencrypt_real_host) {
+    if ($::fqdn == $letsencrypt_host) {
         class { '::letsencrypt::setup::puppetmaster' :
             manage_packages => $manage_packages,
         }
@@ -117,12 +109,10 @@ class letsencrypt (
         }
     }
 
-
     ::letsencrypt::certificate { $domains :
-        letsencrypt_host => $letsencrypt_real_host,
+        letsencrypt_host => $letsencrypt_host,
         challengetype    => $challengetype,
         dh_param_size    => $dh_param_size,
     }
-
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,22 +69,20 @@
 #
 class letsencrypt (
     $domains = [],
-    $letsencrypt_sh_git_url = 'https://github.com/lukas2511/dehydrated.git',
+    $letsencrypt_sh_git_url = $::letsencrypt::params::letsencrypt_sh_git_url,
     $dehydrated_git_url = $letsencrypt_sh_git_url,
-    $challengetype = 'dns-01',
+    $challengetype = $::letsencrypt::params::challengetype,
     $hook_source = undef,
     $hook_content = undef,
-    $letsencrypt_host = pick($::servername, $::puppetmaster),
-    $letsencrypt_ca = 'https://acme-v01.api.letsencrypt.org/directory',
+    $letsencrypt_host = $::letsencrypt::params::letsencrypt_host,
+    $letsencrypt_ca = $::letsencrypt::params::letsencrypt_ca,
     $letsencrypt_contact_email = undef,
     $letsencrypt_proxy = undef,
-    $dh_param_size = 2048,
-    $manage_packages = true,
-){
+    $dh_param_size = $::letsencrypt::params::dh_param_size,
+    $manage_packages = $::letsencrypt::params::manage_packages,
+) inherits ::letsencrypt::params {
 
-    require ::letsencrypt::params
     require ::letsencrypt::setup
-
 
     if ($::fqdn == $letsencrypt_host) {
         class { '::letsencrypt::setup::puppetmaster' :
@@ -111,12 +109,10 @@ class letsencrypt (
         }
     }
 
-
     ::letsencrypt::certificate { $domains :
         letsencrypt_host => $letsencrypt_host,
         challengetype    => $challengetype,
         dh_param_size    => $dh_param_size,
     }
-
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,4 +30,18 @@ class letsencrypt::params {
 
     $letsencrypt_chain_request = "${handler_base_dir}/letsencrypt_get_certificate_chain.sh"
     $letsencrypt_ocsp_request = "${handler_base_dir}/letsencrypt_get_certificate_ocsp.sh"
+
+    if defined('$puppetmaster') {
+        $letsencrypt_host = $::puppetmaster
+    } elsif defined('$servername') {
+        $letsencrypt_host = $::servername
+    }
+    
+    $letsencrypt_sh_git_url = 'https://github.com/lukas2511/dehydrated.git'
+    $dehydrated_git_url = $letsencrypt_sh_git_url
+    $challengetype = 'dns-01'
+    $letsencrypt_ca = 'https://acme-v01.api.letsencrypt.org/directory'
+    $dh_param_size = 2048
+    $manage_packages = true
+    
 }


### PR DESCRIPTION
Change init.pp to inherit params.  Also check if $::puppetmaster variable is defined to get rid of warning on puppetmaster.