### PR TITLE
Make base_dir and handler_base_dir dynamic

### DIFF
--- a/lib/facter/letsencrypyt_crt.rb
+++ b/lib/facter/letsencrypyt_crt.rb
@@ -1,7 +1,12 @@
 
 require 'facter'
 
-crt_domains = Dir['/opt/letsencrypt/requests/*/*.crt'].map { |a| a.gsub(%r{\.crt$}, '').gsub(%r{^.*/}, '') }
+begin
+  basedir = File.read("/etc/letsencrypt.handler_basedir").chomp
+rescue
+  basedir = "/opt/letsencrypt"
+end
+crt_domains = Dir["#{basedir}/requests/*/*.crt"].map { |a| a.gsub(%r{\.crt$}, '').gsub(%r{^.*/}, '') }
 
 Facter.add(:letsencrypt_crts) do
   setcode do

--- a/lib/facter/letsencrypyt_csr.rb
+++ b/lib/facter/letsencrypyt_csr.rb
@@ -1,8 +1,19 @@
 
 require 'facter'
 
-csr_domains = Dir['/etc/letsencrypt/csr/*.csr'].map { |a| a.gsub(%r{\.csr$}, '').gsub(%r{^.*/}, '') }
+begin
+  basedir = File.read("/etc/letsencrypt.basedir").chomp
+rescue
+  basedir = "/etc/letsencrypt"
+end
+csr_domains = Dir["#{basedir}/csr/*.csr"].map { |a| a.gsub(%r{\.csr$}, '').gsub(%r{^.*/}, '') }
 
+Facter.add(:letsencrypt_basedir) do
+  setcode do
+      basedir
+  end
+end
+  
 Facter.add(:letsencrypt_csrs) do
   setcode do
     csr_domains.join(',') if csr_domains
@@ -12,7 +23,7 @@ end
 csr_domains.each do |csr_domain|
   Facter.add('letsencrypt_csr_' + csr_domain) do
     setcode do
-      csr = File.read("/etc/letsencrypt/csr/#{csr_domain}.csr")
+      csr = File.read("#{basedir}/csr/#{csr_domain}.csr")
       csr
     end
   end

--- a/manifests/certificate.pp
+++ b/manifests/certificate.pp
@@ -44,7 +44,6 @@ define letsencrypt::certificate (
     validate_re($challengetype, '^(http-01|dns-01)$')
     validate_string($domain)
 
-    require ::letsencrypt::params
     require ::letsencrypt::setup
 
     ::letsencrypt::deploy { $domain :

--- a/manifests/csr.pp
+++ b/manifests/csr.pp
@@ -38,7 +38,6 @@ define letsencrypt::csr(
     $force = true,
     $dh_param_size = 2048,
 ) {
-    require ::letsencrypt::params
 
     validate_string($letsencrypt_host)
     validate_string($country)
@@ -51,10 +50,10 @@ define letsencrypt::csr(
     validate_string($email)
     validate_integer($dh_param_size)
 
-    $base_dir = $::letsencrypt::params::base_dir
-    $csr_dir  = $::letsencrypt::params::csr_dir
-    $key_dir  = $::letsencrypt::params::key_dir
-    $crt_dir  = $::letsencrypt::params::crt_dir
+    $base_dir = $::letsencrypt::base_dir
+    $csr_dir  = $::letsencrypt::csr_dir
+    $key_dir  = $::letsencrypt::key_dir
+    $crt_dir  = $::letsencrypt::crt_dir
 
     $domains = split($domain_list, ' ')
     $domain = $domains[0]

--- a/manifests/deploy/crt.pp
+++ b/manifests/deploy/crt.pp
@@ -31,10 +31,8 @@ define letsencrypt::deploy::crt(
     $domain = $name
 ) {
 
-    require ::letsencrypt::params
-
-    $crt_dir                 = $::letsencrypt::params::crt_dir
-    $key_dir                 = $::letsencrypt::params::key_dir
+    $crt_dir                 = $::letsencrypt::crt_dir
+    $key_dir                 = $::letsencrypt::key_dir
     $crt                     = "${crt_dir}/${domain}.crt"
     $ocsp                    = "${crt_dir}/${domain}.crt.ocsp"
     $key                     = "${key_dir}/${domain}.key"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,6 +80,18 @@ class letsencrypt (
     $letsencrypt_proxy = undef,
     $dh_param_size = $::letsencrypt::params::dh_param_size,
     $manage_packages = $::letsencrypt::params::manage_packages,
+    $base_dir = $::letsencrypt::params::base_dir,
+    $csr_dir = "${base_dir}/csr",
+    $crt_dir = "${base_dir}/certs",
+    $key_dir = "${base_dir}/private",
+    $handler_base_dir = $::letsencrypt::params::handler_base_dir,
+    $handler_requests_dir = "${handler_base_dir}/requests",
+    $dehydrated_dir = "${handler_base_dir}/dehydrated",
+    $dehydrated_hook = "${handler_base_dir}/letsencrypt_hook",
+    $dehydrated_conf = "${handler_base_dir}/letsencrypt.conf",
+    $dehydrated = "${dehydrated_dir}/dehydrated",
+    $letsencrypt_chain_request = $::letsencrypt::params::letsencrypt_chain_request,
+    $letsencrypt_ocsp_request = $::letsencrypt::params::letsencrypt_ocsp_request,
 ) inherits ::letsencrypt::params {
 
     require ::letsencrypt::setup

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,20 +16,10 @@
 class letsencrypt::params {
 
     $base_dir = '/etc/letsencrypt'
-    $csr_dir  = "${base_dir}/csr"
-    $key_dir  = "${base_dir}/private"
-    $crt_dir  = "${base_dir}/certs"
-
     $handler_base_dir = '/opt/letsencrypt'
-    $handler_requests_dir  = "${handler_base_dir}/requests"
 
-    $dehydrated_dir  = "${handler_base_dir}/dehydrated"
-    $dehydrated_hook = "${handler_base_dir}/letsencrypt_hook"
-    $dehydrated_conf = "${handler_base_dir}/letsencrypt.conf"
-    $dehydrated      = "${dehydrated_dir}/dehydrated"
-
-    $letsencrypt_chain_request = "${handler_base_dir}/letsencrypt_get_certificate_chain.sh"
-    $letsencrypt_ocsp_request = "${handler_base_dir}/letsencrypt_get_certificate_ocsp.sh"
+    $letsencrypt_chain_request = "letsencrypt_get_certificate_chain.sh"
+    $letsencrypt_ocsp_request = "letsencrypt_get_certificate_ocsp.sh"
 
     if defined('$puppetmaster') {
         $letsencrypt_host = $::puppetmaster

--- a/manifests/request.pp
+++ b/manifests/request.pp
@@ -31,19 +31,17 @@ define letsencrypt::request (
     $altnames = undef,
 ) {
 
-    require ::letsencrypt::params
-
-    $handler_requests_dir = $::letsencrypt::params::handler_requests_dir
+    $handler_requests_dir = $::letsencrypt::handler_requests_dir
 
     $base_dir = "${handler_requests_dir}/${domain}"
     $csr_file = "${base_dir}/${domain}.csr"
     $crt_file = "${base_dir}/${domain}.crt"
     $crt_chain_file     = "${base_dir}/${domain}_ca.pem"
-    $dehydrated     = $::letsencrypt::params::dehydrated
-    $dehydrated_dir = $::letsencrypt::params::dehydrated_dir
-    $dehydrated_hook   = $::letsencrypt::params::dehydrated_hook
-    $dehydrated_conf   = $::letsencrypt::params::dehydrated_conf
-    $letsencrypt_chain_request  = $::letsencrypt::params::letsencrypt_chain_request
+    $dehydrated     = $::letsencrypt::dehydrated
+    $dehydrated_dir = $::letsencrypt::dehydrated_dir
+    $dehydrated_hook   = $::letsencrypt::dehydrated_hook
+    $dehydrated_conf   = $::letsencrypt::dehydrated_conf
+    $letsencrypt_chain_request  = "${::letsencrypt::handler_base_dir}/${::letsencrypt::letsencrypt_chain_request}"
 
 
     File {

--- a/manifests/request/crt.pp
+++ b/manifests/request/crt.pp
@@ -8,9 +8,7 @@ define letsencrypt::request::crt(
     $domain = $name
 ) {
 
-    require ::letsencrypt::params
-
-    $handler_requests_dir = $::letsencrypt::params::handler_requests_dir
+    $handler_requests_dir = $::letsencrypt::handler_requests_dir
     $base_dir             = "${handler_requests_dir}/${domain}"
     $crt_file             = "${base_dir}/${domain}.crt"
     $ocsp_file            = "${base_dir}/${domain}.crt.ocsp"

--- a/manifests/request/handler.pp
+++ b/manifests/request/handler.pp
@@ -37,17 +37,14 @@ class letsencrypt::request::handler(
     $hook_content,
     $letsencrypt_contact_email,
     $letsencrypt_proxy,
-){
-
-    require ::letsencrypt::params
-
-    $handler_base_dir     = $::letsencrypt::params::handler_base_dir
-    $handler_requests_dir = $::letsencrypt::params::handler_requests_dir
-    $dehydrated_dir   = $::letsencrypt::params::dehydrated_dir
-    $dehydrated_hook  = $::letsencrypt::params::dehydrated_hook
-    $dehydrated_conf  = $::letsencrypt::params::dehydrated_conf
-    $letsencrypt_chain_request  = $::letsencrypt::params::letsencrypt_chain_request
-    $letsencrypt_ocsp_request   = $::letsencrypt::params::letsencrypt_ocsp_request
+    $handler_base_dir = $::letsencrypt::params::handler_base_dir,
+    $handler_requests_dir = $::letsencrypt::params::handler_requests_dir,
+    $dehydrated_dir = $::letsencrypt::params::dehydrated_dir,
+    $dehydrated_hook = $::letsencrypt::params::dehydrated_hook,
+    $dehydrated_conf = $::letsencrypt::params::dehydrated_conf,
+    $letsencrypt_chain_request = $::letsencrypt::params::letsencrypt_chain_request,
+    $letsencrypt_ocsp_request = $::letsencrypt::params::letsencrypt_ocsp_request
+) inherits ::letsencrypt::params {
 
     user { 'letsencrypt' :
         gid        => 'letsencrypt',

--- a/manifests/request/handler.pp
+++ b/manifests/request/handler.pp
@@ -37,14 +37,14 @@ class letsencrypt::request::handler(
     $hook_content,
     $letsencrypt_contact_email,
     $letsencrypt_proxy,
-    $handler_base_dir = $::letsencrypt::params::handler_base_dir,
-    $handler_requests_dir = $::letsencrypt::params::handler_requests_dir,
-    $dehydrated_dir = $::letsencrypt::params::dehydrated_dir,
-    $dehydrated_hook = $::letsencrypt::params::dehydrated_hook,
-    $dehydrated_conf = $::letsencrypt::params::dehydrated_conf,
-    $letsencrypt_chain_request = $::letsencrypt::params::letsencrypt_chain_request,
-    $letsencrypt_ocsp_request = $::letsencrypt::params::letsencrypt_ocsp_request
-) inherits ::letsencrypt::params {
+    $handler_base_dir = $::letsencrypt::handler_base_dir,
+    $handler_requests_dir = $::letsencrypt::handler_requests_dir,
+    $dehydrated_dir = $::letsencrypt::dehydrated_dir,
+    $dehydrated_hook = $::letsencrypt::dehydrated_hook,
+    $dehydrated_conf = $::letsencrypt::dehydrated_conf,
+    $letsencrypt_chain_request = "${handler_base_dir}/${::letsencrypt::letsencrypt_chain_request}",
+    $letsencrypt_ocsp_request = "${handler_base_dir}/${::letsencrypt::letsencrypt_ocsp_request}",
+) {
 
     user { 'letsencrypt' :
         gid        => 'letsencrypt',
@@ -64,6 +64,10 @@ class letsencrypt::request::handler(
         mode   => '0755',
         owner  => 'letsencrypt',
         group  => 'letsencrypt',
+    }
+    file { "/etc/letsencrypt.handler_basedir":
+        ensure  => file,
+        content => $handler_base_dir,
     }
     file { "${handler_base_dir}/.acme-challenges" :
         ensure => directory,

--- a/manifests/request/ocsp.pp
+++ b/manifests/request/ocsp.pp
@@ -7,14 +7,12 @@ define letsencrypt::request::ocsp(
     $domain = $name
 ) {
 
-    require ::letsencrypt::params
-
-    $handler_requests_dir = $::letsencrypt::params::handler_requests_dir
+    $handler_requests_dir = $::letsencrypt::handler_requests_dir
     $base_dir             = "${handler_requests_dir}/${domain}"
     $crt_file             = "${base_dir}/${domain}.crt"
     $crt_chain_file       = "${base_dir}/${domain}_ca.pem"
     $ocsp_file            = "${crt_file}.ocsp"
-    $letsencrypt_ocsp_request = $::letsencrypt::params::letsencrypt_ocsp_request
+    $letsencrypt_ocsp_request = "${::letsencrypt::handler_base_dir}/${::letsencrypt::letsencrypt_ocsp_request}"
 
     $ocsp_command = join([
         $letsencrypt_ocsp_request,

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -11,9 +11,11 @@
 # Copyright 2016 Bernd Zeimetz
 #
 class letsencrypt::setup (
-){
-
-    require ::letsencrypt::params
+    $base_dir = $::letsencrypt::params::base_dir,
+    $csr_dir = $::letsencrypt::params::csr_dir,
+    $crt_dir = $::letsencrypt::params::crt_dir,
+    $key_dir = $::letsencrypt::params::key_dir
+) inherits ::letsencrypt::params {
 
     group { 'letsencrypt' :
         ensure => present,
@@ -27,13 +29,10 @@ class letsencrypt::setup (
         require => Group['letsencrypt'],
     }
 
-    file { $::letsencrypt::params::base_dir :
-    }
-    file { $::letsencrypt::params::csr_dir :
-    }
-    file { $::letsencrypt::params::crt_dir :
-    }
-    file { $::letsencrypt::params::key_dir :
+    file { $base_dir : }
+    file { $csr_dir : }
+    file { $crt_dir : }
+    file { $key_dir :
         mode    => '0750',
     }
 

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -11,11 +11,7 @@
 # Copyright 2016 Bernd Zeimetz
 #
 class letsencrypt::setup (
-    $base_dir = $::letsencrypt::params::base_dir,
-    $csr_dir = $::letsencrypt::params::csr_dir,
-    $crt_dir = $::letsencrypt::params::crt_dir,
-    $key_dir = $::letsencrypt::params::key_dir
-) inherits ::letsencrypt::params {
+) {
 
     group { 'letsencrypt' :
         ensure => present,
@@ -29,12 +25,16 @@ class letsencrypt::setup (
         require => Group['letsencrypt'],
     }
 
-    file { $base_dir : }
-    file { $csr_dir : }
-    file { $crt_dir : }
-    file { $key_dir :
+    file { $::letsencrypt::base_dir : }
+    file { $::letsencrypt::csr_dir : }
+    file { $::letsencrypt::crt_dir : }
+    file { $::letsencrypt::key_dir :
         mode    => '0750',
     }
 
+    file { "/etc/letsencrypt.basedir":
+        ensure      => file,
+        content     => $::letsencrypt::base_dir
+    }
 
 }


### PR DESCRIPTION
Set of commits to make base_dir (/etc/letsencrypt by default) and handler_base_dir (/opt/letsencrypt) dynamic, that is able to be set as a parameter, eg:

```
class { 'letsencrypt' :
	base_dir						=> "/srv/www/letsencrypt",
	handler_base_dir				=> "/srv/www/letsencrypt_master",
}
```

It sets two files:
 /etc/letsencrypt.basedir
 /etc/letsencrypt_handler_basedir
These files contain just the location of the directories on a single line, and are read by the custom facts.  This is the only way to make the custom facts dynamic, as they are read on the client before any manifests are compiled.

It also necessitated refactor of parameters as params that use base_dir and handler_base_dir can't be set in params.pp otherwise they are not dynamic, and call of params from other defines/classes also has to be done through init.pp params (which is a good thing anyway, probably).  Flow and layout of params is cleaner now.

Default behaviour is as before.