### PR TITLE
Allow for passing configuration data to dehydrated hooks (#30)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,6 +74,7 @@ class letsencrypt (
     $challengetype = $::letsencrypt::params::challengetype,
     $hook_source = undef,
     $hook_content = undef,
+    $hook_env = $::letsencrypt::params::dehydrated_hook_env,
     $letsencrypt_host = $::letsencrypt::params::letsencrypt_host,
     $letsencrypt_ca = $::letsencrypt::params::letsencrypt_ca,
     $letsencrypt_contact_email = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,6 +30,11 @@
 #   dehydrated hook.
 #   hook_source or hook_content needs to be specified.
 #
+# [*hook_env*]
+#   Additional environment variables to set when calling the
+#   verification hook. For example, credentials can be passed
+#   this way. This setting is optional.
+#
 # [*letsencrypt_host*]
 #   The host you want to run dehydrated on.
 #   For now it needs to be a puppetmaster, as it needs direct access

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,10 +23,11 @@ class letsencrypt::params {
     $handler_base_dir = '/opt/letsencrypt'
     $handler_requests_dir  = "${handler_base_dir}/requests"
 
-    $dehydrated_dir  = "${handler_base_dir}/dehydrated"
-    $dehydrated_hook = "${handler_base_dir}/letsencrypt_hook"
-    $dehydrated_conf = "${handler_base_dir}/letsencrypt.conf"
-    $dehydrated      = "${dehydrated_dir}/dehydrated"
+    $dehydrated_dir      = "${handler_base_dir}/dehydrated"
+    $dehydrated_hook     = "${handler_base_dir}/letsencrypt_hook"
+    $dehydrated_hook_env =  []
+    $dehydrated_conf     = "${handler_base_dir}/letsencrypt.conf"
+    $dehydrated          = "${dehydrated_dir}/dehydrated"
 
     $letsencrypt_chain_request = "${handler_base_dir}/letsencrypt_get_certificate_chain.sh"
     $letsencrypt_ocsp_request = "${handler_base_dir}/letsencrypt_get_certificate_ocsp.sh"

--- a/manifests/request.pp
+++ b/manifests/request.pp
@@ -42,6 +42,7 @@ define letsencrypt::request (
     $dehydrated     = $::letsencrypt::params::dehydrated
     $dehydrated_dir = $::letsencrypt::params::dehydrated_dir
     $dehydrated_hook   = $::letsencrypt::params::dehydrated_hook
+    $dehydrated_hook_env = $::letsencrypt::params::dehydrated_hook_env
     $dehydrated_conf   = $::letsencrypt::params::dehydrated_conf
     $letsencrypt_chain_request  = $::letsencrypt::params::letsencrypt_chain_request
 
@@ -95,12 +96,13 @@ define letsencrypt::request (
     ], ' ')
 
     exec { "create-certificate-${domain}" :
-        user    => 'letsencrypt',
-        cwd     => $dehydrated_dir,
-        group   => 'letsencrypt',
-        unless  => $le_check_command,
-        command => $le_command,
-        require => [
+        user        => 'letsencrypt',
+        cwd         => $dehydrated_dir,
+        group       => 'letsencrypt',
+        unless      => $le_check_command,
+        command     => $le_command,
+        environment => $dehydrated_hook_env,
+        require     => [
             User['letsencrypt'],
             Group['letsencrypt'],
             File[$csr_file],

--- a/manifests/request.pp
+++ b/manifests/request.pp
@@ -42,7 +42,7 @@ define letsencrypt::request (
     $dehydrated     = $::letsencrypt::params::dehydrated
     $dehydrated_dir = $::letsencrypt::params::dehydrated_dir
     $dehydrated_hook   = $::letsencrypt::params::dehydrated_hook
-    $dehydrated_hook_env = $::letsencrypt::params::dehydrated_hook_env
+    $dehydrated_hook_env = $::letsencrypt::hook_env
     $dehydrated_conf   = $::letsencrypt::params::dehydrated_conf
     $letsencrypt_chain_request  = $::letsencrypt::params::letsencrypt_chain_request
 


### PR DESCRIPTION
This allows setting additional environment variables to be passted to the dehydrated hook, e.g. for configuring credentials used with DNS verification