### PR TITLE
Allow managing user and group externally

### DIFF
--- a/manifests/csr.pp
+++ b/manifests/csr.pp
@@ -94,7 +94,7 @@ define letsencrypt::csr(
             File[$crt_dir]
         ],
         user    => 'root',
-        group   => 'letsencrypt',
+        group   => $::letsencrypt::group,
         command => "/usr/bin/openssl dhparam -check ${dh_param_size} -out ${dh}",
         unless  => $create_dh_unless,
         timeout => 30*60,
@@ -103,7 +103,7 @@ define letsencrypt::csr(
     file { $dh :
         ensure  => $ensure,
         owner   => 'root',
-        group   => 'letsencrypt',
+        group   => $::letsencrypt::group,
         mode    => '0644',
         require => Exec["create-dh-${dh}"],
     }
@@ -111,7 +111,7 @@ define letsencrypt::csr(
     file { $cnf :
         ensure  => $ensure,
         owner   => 'root',
-        group   => 'letsencrypt',
+        group   => $::letsencrypt::group,
         mode    => '0644',
         content => template('letsencrypt/cert.cnf.erb'),
     }
@@ -135,7 +135,7 @@ define letsencrypt::csr(
         command     => "rm -f ${csr}",
         refreshonly => true,
         user        => 'root',
-        group       => 'letsencrypt',
+        group       => $::letsencrypt::group,
         before      => X509_request[$csr],
         subscribe   => File[$cnf],
     }
@@ -143,14 +143,14 @@ define letsencrypt::csr(
     file { $key :
         ensure  => $ensure,
         owner   => 'root',
-        group   => 'letsencrypt',
+        group   => $::letsencrypt::group,
         mode    => '0640',
         require => Ssl_pkey[$key],
     }
     file { $csr :
         ensure  => $ensure,
         owner   => 'root',
-        group   => 'letsencrypt',
+        group   => $::letsencrypt::group,
         mode    => '0644',
         require => X509_request[$csr],
     }

--- a/manifests/deploy/crt.pp
+++ b/manifests/deploy/crt.pp
@@ -46,7 +46,7 @@ define letsencrypt::deploy::crt(
     file { $crt :
         ensure  => file,
         owner   => root,
-        group   => letsencrypt,
+        group   => $::letsencrypt::group,
         content => $crt_content,
         mode    => '0644',
     }
@@ -55,7 +55,7 @@ define letsencrypt::deploy::crt(
         file { $ocsp :
             ensure  => file,
             owner   => root,
-            group   => letsencrypt,
+            group   => $::letsencrypt::group,
             content => base64('decode', $ocsp_content),
             mode    => '0644',
         }
@@ -68,12 +68,12 @@ define letsencrypt::deploy::crt(
 
     concat { $crt_full_chain :
         owner => root,
-        group => letsencrypt,
+        group => $::letsencrypt::group,
         mode  => '0644',
     }
     concat { $crt_full_chain_with_key :
         owner => root,
-        group => letsencrypt,
+        group => $::letsencrypt::group,
         mode  => '0640',
     }
 
@@ -105,7 +105,7 @@ define letsencrypt::deploy::crt(
         file { $crt_chain :
             ensure  => file,
             owner   => root,
-            group   => letsencrypt,
+            group   => $::letsencrypt::group,
             content => $crt_chain_content,
             mode    => '0644',
         }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,6 +80,9 @@ class letsencrypt (
     $letsencrypt_proxy = undef,
     $dh_param_size = $::letsencrypt::params::dh_param_size,
     $manage_packages = $::letsencrypt::params::manage_packages,
+    $manage_user = $::letsencrypt::params::manage_user,
+    $user = $::letsencrypt::params::user,
+    $group = $::letsencrypt::params::group,
 ) inherits ::letsencrypt::params {
 
     require ::letsencrypt::setup

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,4 +44,7 @@ class letsencrypt::params {
     $dh_param_size = 2048
     $manage_packages = true
 
+    $manage_user = true
+    $user = 'letsencrypt'
+    $group = 'letsencrypt'
 }

--- a/manifests/request.pp
+++ b/manifests/request.pp
@@ -47,11 +47,11 @@ define letsencrypt::request (
 
 
     File {
-        owner   => 'letsencrypt',
-        group   => 'letsencrypt',
+        owner   => $::letsencrypt::user,
+        group   => $::letsencrypt::group,
         require => [
-            User['letsencrypt'],
-            Group['letsencrypt']
+            User[$::letsencrypt::user],
+            Group[$::letsencrypt::group]
         ],
     }
 
@@ -95,14 +95,14 @@ define letsencrypt::request (
     ], ' ')
 
     exec { "create-certificate-${domain}" :
-        user    => 'letsencrypt',
+        user    => $::letsencrypt::user,
         cwd     => $dehydrated_dir,
-        group   => 'letsencrypt',
+        group   => $::letsencrypt::group,
         unless  => $le_check_command,
         command => $le_command,
         require => [
-            User['letsencrypt'],
-            Group['letsencrypt'],
+            User[$::letsencrypt::user],
+            Group[$::letsencrypt::group],
             File[$csr_file],
             Vcsrepo[$dehydrated_dir],
             File[$dehydrated_hook],
@@ -122,8 +122,8 @@ define letsencrypt::request (
             File[$letsencrypt_chain_request]
         ],
         refreshonly => true,
-        user        => letsencrypt,
-        group       => letsencrypt,
+        user        => $::letsencrypt::user,
+        group       => $::letsencrypt::group,
         command     => $get_certificate_chain_command,
         timeout     => 5*60,
         tries       => 2,

--- a/manifests/request/handler.pp
+++ b/manifests/request/handler.pp
@@ -49,12 +49,14 @@ class letsencrypt::request::handler(
     $letsencrypt_chain_request  = $::letsencrypt::params::letsencrypt_chain_request
     $letsencrypt_ocsp_request   = $::letsencrypt::params::letsencrypt_ocsp_request
 
-    user { 'letsencrypt' :
-        gid        => 'letsencrypt',
-        home       => $handler_base_dir,
-        shell      => '/bin/bash',
-        managehome => false,
-        password   => '!!',
+    if $::letsencrypt::manage_user {
+        user { $::letsencrypt::user:
+            gid        => $::letsencrypt::group,
+            home       => $handler_base_dir,
+            shell      => '/bin/bash',
+            managehome => false,
+            password   => '!!',
+        }
     }
 
     File {
@@ -65,14 +67,14 @@ class letsencrypt::request::handler(
     file { $handler_base_dir :
         ensure => directory,
         mode   => '0755',
-        owner  => 'letsencrypt',
-        group  => 'letsencrypt',
+        owner  => $::letsencrypt::user,
+        group  => $::letsencrypt::group,
     }
     file { "${handler_base_dir}/.acme-challenges" :
         ensure => directory,
         mode   => '0755',
-        owner  => 'letsencrypt',
-        group  => 'letsencrypt',
+        owner  => $::letsencrypt::user,
+        group  => $::letsencrypt::group,
     }
     file { $handler_requests_dir :
         ensure => directory,
@@ -81,8 +83,8 @@ class letsencrypt::request::handler(
 
     file { $dehydrated_hook :
         ensure  => file,
-        group   => 'letsencrypt',
-        require => Group['letsencrypt'],
+        group   => $::letsencrypt::group,
+        require => Group[$::letsencrypt::group],
         source  => $hook_source,
         content => $hook_content,
         mode    => '0750',
@@ -120,7 +122,7 @@ class letsencrypt::request::handler(
     file { $dehydrated_conf :
         ensure  => file,
         owner   => root,
-        group   => letsencrypt,
+        group   => $::letsencrypt::group,
         mode    => '0640',
         content => template('letsencrypt/letsencrypt.conf.erb'),
     }
@@ -128,7 +130,7 @@ class letsencrypt::request::handler(
     file { $letsencrypt_chain_request :
         ensure  => file,
         owner   => root,
-        group   => letsencrypt,
+        group   => $::letsencrypt::group,
         mode    => '0755',
         content => template('letsencrypt/letsencrypt_get_certificate_chain.sh.erb'),
     }
@@ -136,7 +138,7 @@ class letsencrypt::request::handler(
     file { $letsencrypt_ocsp_request :
         ensure  => file,
         owner   => root,
-        group   => letsencrypt,
+        group   => $::letsencrypt::group,
         mode    => '0755',
         content => template('letsencrypt/letsencrypt_get_certificate_ocsp.sh.erb'),
     }

--- a/manifests/request/ocsp.pp
+++ b/manifests/request/ocsp.pp
@@ -47,8 +47,8 @@ define letsencrypt::request::ocsp(
         command => $ocsp_command,
         unless  => $ocsp_unless,
         onlyif  => $ocsp_onlyif,
-        user    => letsencrypt,
-        group   => letsencrypt,
+        user    => $::letsencrypt::user,
+        group   => $::letsencrypt::group,
         require => File[$letsencrypt_ocsp_request],
     }
 

--- a/manifests/setup.pp
+++ b/manifests/setup.pp
@@ -15,16 +15,18 @@ class letsencrypt::setup (
 
     require ::letsencrypt::params
 
-    group { 'letsencrypt' :
-        ensure => present,
+    if $::letsencrypt::manage_user {
+        group { $::letsencrypt::group :
+            ensure => present,
+        }
     }
 
     File {
         ensure  => directory,
         owner   => 'root',
-        group   => 'letsencrypt',
+        group   => $::letsencrypt::group,
         mode    => '0755',
-        require => Group['letsencrypt'],
+        require => Group[$::letsencrypt::group],
     }
 
     file { $::letsencrypt::params::base_dir :


### PR DESCRIPTION
Fixes #28

Adds three parameters:
  - manage_user: bool, default true
  - user: string, default letsencrypt
  - group: string, default letsencrypt

Then uses those parameters exclusively when referring to the name of the user or group. If `$manage_user` is false, the user and group are assumed to be created outside of the module.

Note that this PR could do with a rebase on top of #25 because the params pattern fixup is necessary to override the values properly (otherwise the values are hard-coded in params.pp, or not required before use).
