### PR TITLE
Fix typo

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -93,7 +93,6 @@ class letsencrypt (
 ) inherits ::letsencrypt::params {
 
     require ::letsencrypt::setup
-    $letsencrypt_cas = $::letsencrypt::params::letsencrypt_cas
 
     if ($::fqdn == $letsencrypt_host) {
         class { '::letsencrypt::setup::puppetmaster' :


### PR DESCRIPTION
I obtain this error when eI use the current master:

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Cannot reassign variable '$letsencrypt_cas' at /etc/puppetlabs/code/environments/production/modules/letsencrypt/manifests/init.pp:96:22  ......
```