### PR TITLE
Facter available certs

### DIFF
--- a/lib/facter/letsencrypyt_certs.rb
+++ b/lib/facter/letsencrypyt_certs.rb
@@ -1,0 +1,10 @@
+
+require 'facter'
+
+crt_domains = Dir['/etc/letsencrypt/certs/*.crt'].map { |a| a.gsub(%r{\.crt$}, '').gsub(%r{^.*/}, '') }
+
+Facter.add(:letsencrypt_certs) do
+  setcode do
+    crt_domains
+  end
+end


### PR DESCRIPTION
This PR exposes the list of certs available from Let's Encrypt (`/etc/letsencrypt/certs/*.crt`) as an array. It does no checking beyond that the files exist. 

This allows someone to check the facts for an available cert, and act accordingly. 

Example:
```
        if ($name in $facts['letsencrypt_certs']) {
            notify {"Found ${name} cert, configuring for SSL": }
        }
```

This can be extended to add SSL configurations to a hash for applying to servers when SSL exists, or not applying a full vhost if SSL is required. 

This should maybe be extended to checking for valid cert, and/or exposing some of the cert values (example SAN, Valid Dates). However, this is a decent starting point. 
