### PR TITLE
Update usage of getvar for puppet 6 compatibility

### DIFF
--- a/manifests/csr.pp
+++ b/manifests/csr.pp
@@ -154,7 +154,7 @@ define letsencrypt::csr(
         require => X509_request[$csr],
     }
 
-    $csr_content = pick_default(getvar("::letsencrypt_csr_${domain}"), '')
+    $csr_content = pick_default(getvar("::letsencrypt_csr_${domain}"), getvar("::facts.'letsencrypt_csr_${domain}'"), '')
     if ($csr_content =~ /CERTIFICATE REQUEST/) {
         @@letsencrypt::request { $domain :
             csr           => $csr_content,


### PR DESCRIPTION
With puppet6, getvar was made a core function and replaces stdlib
version. The behaviour is slightly different with respect to dots within
the key name, which are now treated as data structure traversal
operators and thus the `letsencrypt_csr_${domain}` fact lookup no longer
works.

This commit changes the lookup in a backward compatible way to find the
csr fact under puppet6.

Fixes #42